### PR TITLE
Fix Alignment not triggering onChange

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,9 @@ class AlignmentBlockTune {
                 this.data = {
                     alignment: this.alignmentSettings[index].name
                 }
+
+                this.block?.dispatchChange()
+                
                 elements.forEach((el, i) => {
                     const {name} = this.alignmentSettings[i];
                     el.classList.toggle(this.api.styles.settingsButtonActive, name === this.data.alignment);


### PR DESCRIPTION
fixes #12
Uses https://editorjs.io/blockapi/#dispatchchange to tell the editor that the block has been changed.